### PR TITLE
add short options, output filename

### DIFF
--- a/polymaze/cli.py
+++ b/polymaze/cli.py
@@ -16,48 +16,45 @@ def commandline():
     parser = _parser()
     kwargs = vars(parser.parse_args())
     # setup the base grid with a supershape if provided
-    ss_name = kwargs.pop('shape')
-    if ss_name:
-        supershape = ss_dict[ss_name]
-    else:
-        supershape = None
-    grid = PolyGrid(supershape=supershape)
+    grid = PolyGrid(supershape=ss_dict.get(kwargs.pop('shape'), None))
 
     # pull off non-common parameters
     string = kwargs.pop('string')
     image_path = kwargs.pop('image')
     font_path = kwargs.pop('font')
+    filename = kwargs.pop('output')
 
     # fill the grid and create maze based on the remaining arguments provided
     if string:
         grid.create_string(string, font_path=font_path, **kwargs)
-        maze = Maze(grid)
-        save_maze(maze, 'String')
+        maze_type = 'String'
     elif image_path:
         image = PIL.Image.open(image_path).convert('L')
         if not image:
             print('Unable to open the provided image path: {}'
                   ''.format(image_path))
         grid.create_from_image(image, **kwargs)
-        maze = Maze(grid)
-        save_maze(maze, 'Image')
+        maze_type = 'Image'
     else:
         grid.create_rectangle(**kwargs)
-        maze = Maze(grid)
-        save_maze(maze, 'Rectangle')
+        maze_type = 'Rectangle'
+
+    maze = Maze(grid)
+    save_maze(maze, maze_type, filename)
 
 
-def save_maze(maze, maze_type):
+def save_maze(maze, maze_type, filename=None):
     image = maze.image()
     if image is None:
         print('This maze appears to be empty. Not saving.')
     else:
         now_str = str(datetime.now().time())
         clean_now_string = now_str.replace(':', '.').rsplit('.', 1)[0]
-        filename = '{} - {} made with {}.png'.format(clean_now_string,
-                                                     maze_type,
-                                                     maze.shape_name())
-        image.save(filename, format='PNG')
+        if filename is None:
+            filename = '{} - {} made with {}.png'.format(clean_now_string,
+                                                         maze_type,
+                                                         maze.shape_name())
+        image.save(filename)
         print(filename)
 
 
@@ -65,23 +62,24 @@ def _parser():
     parser = argparse.ArgumentParser(description='Make and save mazes.')
     # optional top level type of maze to make (default rectangle)
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('--string',
+    group.add_argument('-s', '--string',
                        help='Make a maze for each character in STRING.')
-    group.add_argument('--image',
+    group.add_argument('-i', '--image',
                        help='Make a maze from IMAGE (path).')
     # optional complexity
-    parser.add_argument('--complexity', type=_positive,
+    parser.add_argument('-c', '--complexity', type=_positive,
                         help='Numeric scale for complexity.'
-                             ' 0.5 is easy. 100 is WTFImpossible.')
+                             ' 0.5 is easy. 100 is WTFImpossible (tm).')
      # optional shape to use
     ss_names = ss_dict.keys()
-    parser.add_argument('--shape', choices=ss_names,
+    parser.add_argument('-S', '--shape', choices=ss_names,
                         help='Make the maze with this shape. Random otherwise.')
     # optional aspect (relative height)
-    parser.add_argument('--aspect', type=_positive,
+    parser.add_argument('-a', '--aspect', type=_positive,
                         help='Set the height/width aspect of the maze.')
-    parser.add_argument('--font', type=str,
+    parser.add_argument('-f', '--font', type=str,
                         help='Provide a font name/path for string mazes.')
+    parser.add_argument('-o', '--output', type=str, help='Output filename.')
     return parser
 
 


### PR DESCRIPTION
I think with short option names would be easier to use this program, but I think renaming `string` to `text` for `-t` might be a good idea, so it doesn't have to have `-S` for shape.

I removed the `format` argument, PIL should have no problem to decide the format based on the filename extension, this way, user can simply give names like `foobar.gif` or `foobar.jpeg` and they will be saved with correct format.

By the way, I put in `(tm)`, just push the humor to another level.
